### PR TITLE
update seeds for trails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 2.4.1
+env:
+  - DB=postgresql
+script:
+  - RAILS_ENV=test bundle exec rake db:create db:migrate --trace
+  - bundle exec rspec
+before_script:
+  - cp config/database.travis.yml config/database.yml
+bundler_args: --binstubs=./bundler_stubs

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,7 @@
+default: &default
+  adapter: postgresql
+test:
+  <<: *default
+  database: mydb_test
+  username: travis
+  encoding: utf8

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,20 +115,32 @@ class Seed
   end
 
   def generate_trails(n)
-    n.times do |i|
-      trail = Trail.new(
-        name: "#{prefix} #{Faker::Zelda.location} #{suffix}",
-        description: Faker::Hobbit.quote,
-        distance: %w(5,10,15,20,25,50,100).sample,
-        rating: %w(1,2,3,4).sample,
-        longitude: longitude,
-        latitude: latitude
-      )
+    max_attrs =
+      {
+        lat: 39.742043,
+        lon: -104.991531,
+        maxResults: 500,
+        maxDistance: 200
+      }
+    HikingProjectService.search(max_attrs)[:trails].each do |trail|
+      1.times do |i|
+        valid_attrs = {
+          name: trail[:name],
+          description: trail[:summary],
+          location: trail[:location],
+          distance: trail[:length],
+          rating: trail[:difficulty],
+          longitude: trail[:longitude],
+          latitude: trail[:latitude],
+          hp_id: trail[:id]
+        }
+        trail = Trail.new(valid_attrs)
 
-      trail.difficulty = Difficulty.all.sample
-      trail.save
+        trail.difficulty = Difficulty.all.sample
+        trail.save
 
-      puts "User #{i}: #{trail.name} created!"
+        puts "#{Trail.last.id} Total Trails: #{trail.name} created!"
+      end
     end
   end
 

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 2.4.1
+env:
+  - DB=postgresql
+script:
+  - RAILS_ENV=test bundle exec rake db:create db:migrate --trace
+  - bundle exec rspec
+before_script:
+  - cp config/database.travis.yml config/database.yml
+bundler_args: --binstubs=./bundler_stubs


### PR DESCRIPTION
@Mcents @Mcents See Pull Request for updated Trail seeds that @DesTodo and I worked on

There is only one changed file, and we reuse the `HikingProjectService.search(args)` method that was already built, but we override the default arg values and make sure we expand the params to the Max number of results and the max radius from the provided coordinates.  This is found on lines `118:124` in `db/seeds.rb`. It overrides the default attrs in the method below from lines `8:11` in `app/services/hiking_project_service.rb`...
```ruby
  def self.search(search_params = { lat: 39.742043, lon: -104.991531, maxResults: 50 })
    response = new(search_params).search
    JSON.parse(response, :symbolize_names => true)
  end
```

[See Hiking Project documentation here](https://www.hikingproject.com/data)
 - To re-setup your db, run `bundle exec rake db:reset` and you should be good.
